### PR TITLE
chore: Add a minimal version of the counter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ charset = utf-8
 max_line_length = 119
 
 # Use 2 spaces for the HTML files
-[*.html]
+[*{.html,.tpl}]
 indent_size = 2
 
 # The JSON files contain newlines inconsistently

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ lint:
 	@pipenv run security
 
 run:
-	pipenv run python tomaco/app.py
+	pipenv run python -m bottle --debug --reload tomaco.app
 
 setup:
 	pip install pipenv

--- a/tomaco/app.py
+++ b/tomaco/app.py
@@ -1,11 +1,22 @@
-from bottle import app, route, run
+import os
+
+import bottle
+from bottle import app, route, run, static_file, template
+
+PROJECT_PATH = os.path.dirname(__file__)
+bottle.TEMPLATE_PATH.insert(0, os.path.join(PROJECT_PATH, "views"))
 
 application = app()
 
 
+@route("/static/<filepath:path>")
+def server_static(filepath):
+    return static_file(filepath, root=os.path.join(PROJECT_PATH, "static"))
+
+
 @route("/")
 def index():
-    return "Hello world!"
+    return template("index")
 
 
 if __name__ == "__main__":

--- a/tomaco/static/css/main.css
+++ b/tomaco/static/css/main.css
@@ -1,0 +1,9 @@
+.counter {
+    padding: 4rem;
+    text-align: center;
+}
+
+.counter__display {
+    display: block;
+    font-size: 4rem;
+}

--- a/tomaco/tests/test_app.py
+++ b/tomaco/tests/test_app.py
@@ -1,7 +1,12 @@
-def test_index_should_return_valid(app):
-    assert app.get("/").status == "200 OK"
+class TestStatic:
+    def test_css_file_should_return_valid(self, app):
+        assert app.get("/static/css/main.css").status == "200 OK"
 
 
-def test_index_should_return_a_hello_world(app):
-    result = app.get("/")
-    result.mustcontain("Hello world!")
+class TestIndex:
+    def test_index_should_return_valid(self, app):
+        assert app.get("/").status == "200 OK"
+
+    def test_index_should_contain_the_app_name(self, app):
+        result = app.get("/")
+        result.mustcontain("Tomaco")

--- a/tomaco/views/index.tpl
+++ b/tomaco/views/index.tpl
@@ -1,0 +1,31 @@
+<!doctype html>
+<html class="no-js" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Tomaco - Your friendly Pomodoro tracker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#fafafa">
+
+  <link rel="styleshet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="/static/css/main.css">
+</head>
+
+<body>
+  <nav>
+    <div class="nav-wrapper">
+      <a href="#" class="brand-logo center">Tomaco</a>
+    </div>
+  </nav>
+
+  <div class="container">
+    <div class="counter">
+      <span class="counter__display">25:00</span>
+      <button class="waves-effect waves-light btn-large red lighten-2 counter__button">Start!</button>
+    </div>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
By starting the counter/clock page, we can have a better idea about how it's going to look like, and
how we are going to deal with APIs and endpoints.

We are deciding the use of some technologies with this PR:
- [Bottle's default template engine](https://bottlepy.org/docs/dev/stpl.html)
- [BEM as CSS naming convention](https://en.bem.info/methodology/quick-start/)
- [Material Design as our visual language](https://material.io/design/introduction/#principles)
- [MaterializeCSS as front-end framework](https://materializecss.com/)

<img width="336" alt="Screenshot 2019-05-10 at 16 42 12" src="https://user-images.githubusercontent.com/477202/57536236-06c42900-7344-11e9-95c8-984978e16cec.png">

closes #2