### PR TITLE
feat: Add a counter to finished sessions

### DIFF
--- a/tomaco/static/src/css/main.css
+++ b/tomaco/static/src/css/main.css
@@ -7,3 +7,15 @@
   display: block;
   font-size: 4rem;
 }
+
+.timer__finished_counter {
+  padding: 1rem;
+}
+
+.timer__finished_item {
+  background-color: green;
+  border-radius: 100%;
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+}

--- a/tomaco/static/src/js/main.js
+++ b/tomaco/static/src/js/main.js
@@ -7,13 +7,16 @@ const START_TEXT = "Start!";
 const STOP_TEXT = "Stop!";
 
 export default class Timer {
-  constructor($display, $button) {
+  constructor($display, $button, $finishedCounter) {
     this.$display = $display;
     this.$button = $button;
+    this.$finishedCounter = $finishedCounter;
+
     this.seconds = FOCUS_STARTING_FROM;
     this.focusMode = true;
     this.isRunning = false;
     this.timer = null;
+    this.finishedPomodoros = 0;
 
     this.$button.addEventListener("click", this.toggleTimer.bind(this));
   }
@@ -29,6 +32,13 @@ export default class Timer {
 
     this.$button.innerHTML = this.isRunning ? STOP_TEXT : START_TEXT;
     this.$display.innerHTML = secondsToMinutesAndSeconds(this.seconds);
+    this.$finishedCounter.innerHTML = Array.from({
+      length: this.finishedPomodoros
+    }).reduce(
+      accumulator =>
+        `${accumulator} <span class="timer__finished_item"></span>`,
+      ""
+    );
   }
 
   startTimer() {
@@ -61,6 +71,16 @@ export default class Timer {
     this.focusMode = false;
   }
 
+  setPomodoroAsDone() {
+    this.toggleFocusTime();
+    this.stopTimer();
+    this.finishedPomodoros += 1;
+
+    M.toast({
+      html: "Pomodoro done! :)"
+    });
+  }
+
   toggleFocusTime() {
     if (this.focusMode) {
       this.setBreakTime();
@@ -71,11 +91,7 @@ export default class Timer {
 
   timerInterval() {
     if (this.seconds <= 0) {
-      this.toggleFocusTime();
-      this.stopTimer();
-      M.toast({
-        html: "Pomodoro done! :)"
-      });
+      this.setPomodoroAsDone();
     } else {
       this.seconds -= 1;
     }
@@ -83,8 +99,8 @@ export default class Timer {
     this.updateUI();
   }
 
-  static build($display, $button) {
-    const timer = new Timer($display, $button);
+  static build($display, $button, $finishedCounter) {
+    const timer = new Timer($display, $button, $finishedCounter);
     timer.stopTimer();
     timer.updateUI();
 

--- a/tomaco/static/tests/main.spec.js
+++ b/tomaco/static/tests/main.spec.js
@@ -2,6 +2,7 @@ import Timer from "../src/js/main";
 
 describe("Timer", () => {
   let $fakeButton;
+  let $fakeCounter;
   let $fakeDisplay;
   let timer;
   let clearIntervalSpy;
@@ -17,11 +18,14 @@ describe("Timer", () => {
       },
       innerHTML: ""
     };
+    $fakeCounter = {
+      innerHTML: ""
+    };
     $fakeDisplay = {
       innerHTML: ""
     };
 
-    timer = Timer.build($fakeDisplay, $fakeButton);
+    timer = Timer.build($fakeDisplay, $fakeButton, $fakeCounter);
 
     clearIntervalSpy = jest.spyOn(global, "clearInterval");
     setIntervalSpy = jest.spyOn(global, "setInterval");
@@ -36,6 +40,7 @@ describe("Timer", () => {
     it("should reset the timer", () => {
       expect(timer.isRunning).toBe(false);
       expect($fakeButton.innerHTML).toEqual("Start!");
+      expect($fakeCounter.innerHTML).toEqual("");
       expect($fakeDisplay.innerHTML).toEqual("25:00");
     });
 
@@ -97,6 +102,15 @@ describe("Timer", () => {
 
       expect($fakeButton.classList.add).toHaveBeenCalledWith("green");
       expect($fakeButton.classList.remove).toHaveBeenCalledWith("red");
+    });
+
+    it("should add a visual element to inform the user that a session has been completed", () => {
+      timer.setPomodoroAsDone();
+      timer.updateUI();
+
+      expect($fakeCounter.innerHTML).toContain(
+        '<span class="timer__finished_item"></span>'
+      );
     });
   });
 
@@ -173,6 +187,13 @@ describe("Timer", () => {
       expect(M.toast).toHaveBeenCalledWith({
         html: "Pomodoro done! :)"
       });
+    });
+
+    it("should increase the finished counter", () => {
+      timer.seconds = 0;
+      timer.timerInterval();
+
+      expect(timer.finishedPomodoros).toEqual(1);
     });
   });
 });

--- a/tomaco/views/index.tpl
+++ b/tomaco/views/index.tpl
@@ -33,6 +33,8 @@
         >
           Start!
         </button>
+
+        <div class="timer__finished_counter" id="timer__finished_counter"></div>
       </div>
     </div>
 
@@ -42,8 +44,9 @@
       const Timer = require("tomaco/static/src/js/main.js").default;
       const $display = document.getElementById("timer__display");
       const $button = document.getElementById("timer__button");
+      const $finishedCounter = document.getElementById("timer__finished_counter");
 
-      Timer.build($display, $button);
+      Timer.build($display, $button, $finishedCounter);
     </script>
   </body>
 </html>


### PR DESCRIPTION
When the session reaches its end, we are showing a green dot to allow the user to keep track of
his/her progress during the day. We are not storing this progress whatsoever.

<img width="418" alt="Screenshot 2019-06-28 at 14 01 51" src="https://user-images.githubusercontent.com/477202/60341266-37245d00-99ae-11e9-8dbe-209afa73b188.png">


closes #5