### PR TITLE
feat: Send notification when pomodoro done

### DIFF
--- a/tomaco/static/src/js/main.js
+++ b/tomaco/static/src/js/main.js
@@ -1,4 +1,4 @@
-import secondsToMinutesAndSeconds from "./utils";
+import { notify, secondsToMinutesAndSeconds } from "./utils";
 
 const ONE_SECOND = 1 * 1000;
 const FOCUS_STARTING_FROM = 25 * 60;
@@ -112,6 +112,7 @@ export default class Timer {
     this.stopTimer();
     this.finishedPomodoros += 1;
 
+    notify("Pomodoro done! Take a break!");
     M.toast({
       html: "Pomodoro done! :)"
     });

--- a/tomaco/static/src/js/utils.js
+++ b/tomaco/static/src/js/utils.js
@@ -7,4 +7,16 @@ const secondsToMinutesAndSeconds = seconds => {
   return `${formattedMinutes}:${formattedSeconds}`;
 };
 
-export default secondsToMinutesAndSeconds;
+function notify(message) {
+  if (window.Notification && Notification.permission === "granted") {
+    const notification = new Notification(message);
+
+    // open Tomaco's page on click in notification popup
+    notification.onclick = event => {
+      event.preventDefault();
+      window.focus();
+    };
+  }
+}
+
+export { notify, secondsToMinutesAndSeconds };

--- a/tomaco/views/index.tpl
+++ b/tomaco/views/index.tpl
@@ -54,6 +54,9 @@
       const $pauseButton = document.getElementById("pause__button");
 
       Timer.build($display, $button, $finishedCounter, $pauseButton);
+
+      // Request permission to send notifications
+      Notification.requestPermission();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Added a function that receives a message using Notifications API.
When an user opens the Tomaco's page, it will be requested to accept receive notifications.
For now, only sends notifications at pomodoro is done.

closes #23