### PR TITLE
fix: Don't count session as completed when it is a break one

### DIFF
--- a/tomaco/static/src/js/main.js
+++ b/tomaco/static/src/js/main.js
@@ -108,9 +108,12 @@ export default class Timer {
   }
 
   setPomodoroAsDone() {
+    if (this.focusMode) {
+      this.finishedPomodoros += 1;
+    }
+
     this.toggleFocusTime();
     this.stopTimer();
-    this.finishedPomodoros += 1;
 
     notify("Pomodoro done! Take a break!");
     M.toast({

--- a/tomaco/static/tests/main.spec.js
+++ b/tomaco/static/tests/main.spec.js
@@ -35,7 +35,12 @@ describe("Timer", () => {
       innerHTML: ""
     };
 
-    timer = Timer.build($fakeDisplay, $fakeButton, $fakeCounter, $fakePauseButton);
+    timer = Timer.build(
+      $fakeDisplay,
+      $fakeButton,
+      $fakeCounter,
+      $fakePauseButton
+    );
 
     clearIntervalSpy = jest.spyOn(global, "clearInterval");
     setIntervalSpy = jest.spyOn(global, "setInterval");
@@ -152,7 +157,6 @@ describe("Timer", () => {
       timer.togglePauseTimer();
       expect(timer.isPaused).toBe(true);
     });
-
   });
 
   describe("resetTimer", () => {
@@ -235,6 +239,14 @@ describe("Timer", () => {
       timer.timerInterval();
 
       expect(timer.finishedPomodoros).toEqual(1);
+    });
+
+    it("should not increase the finished counter if it was a break session", () => {
+      timer.seconds = 0;
+      timer.setBreakTime();
+      timer.timerInterval();
+
+      expect(timer.finishedPomodoros).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
We were counting a pomodoro as done when a "break session" was being completed. With this fix, the
counter is increased just for pomodoro (focused) sessions.

fix #28