### PR TITLE
chore: add settings to compress JS and CSS build files

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -11,7 +11,25 @@ module.exports = {
     public: "tomaco/static/build",
     watched: ["tomaco/static/src"]
   },
+  npm: {
+    compilers: ["babel-brunch"]
+  },
   plugins: {
-    npm: ["babel-brunch"]
+    cleancss: {
+      keepSpecialComments: 0,
+      removeEmpty: true
+    },
+    terser: {
+      mangle: false,
+      compress: {
+        global_defs: {
+          "@console.log": "alert"
+        },
+      },
+      output: {
+        beautify: false,
+        preamble: "/* minified */"
+      }
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "^1.17.1"
   },
   "scripts": {
-    "build": "brunch build",
+    "build": "brunch build -p",
     "lint": "eslint tomaco/static/src",
     "run": "brunch watch",
     "test": "jest"
@@ -39,6 +39,9 @@
     "@babel/core": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "brunch": "^2.10.17",
-    "babel-brunch": "^7.0.1"
+    "babel-brunch": "^7.0.1",
+    "clean-css-brunch": "^2.10.0",
+    "terser": "^4.0.2",
+    "terser-brunch": "^3.0.0"
   }
 }


### PR DESCRIPTION
Change brunch config file to enable compression of JS and CSS files on project building.

closes: #35