### PR TITLE
fix: Focus and break message in notification

### DIFF
--- a/tomaco/static/src/js/constants.js
+++ b/tomaco/static/src/js/constants.js
@@ -1,0 +1,12 @@
+export const BREAK_STARTING_FROM = 5 * 60;
+export const FOCUS_STARTING_FROM = 25 * 60;
+export const PAUSE_TEXT = "Pause!";
+export const RESUME_TEXT = "Resume!";
+export const ONE_SECOND = 1 * 1000;
+export const START_TEXT = "Start!";
+export const STOP_TEXT = "Stop!";
+
+export const MESSAGES = {
+  FOCUS_MODE_DONE: "Pomodoro done! Take a break.",
+  REST_MODE_DONE: "Get back to work! :D"
+};

--- a/tomaco/static/src/js/main.js
+++ b/tomaco/static/src/js/main.js
@@ -1,12 +1,14 @@
+import {
+  BREAK_STARTING_FROM,
+  FOCUS_STARTING_FROM,
+  MESSAGES,
+  ONE_SECOND,
+  PAUSE_TEXT,
+  RESUME_TEXT,
+  START_TEXT,
+  STOP_TEXT
+} from "./constants";
 import { notify, secondsToMinutesAndSeconds } from "./utils";
-
-const ONE_SECOND = 1 * 1000;
-const FOCUS_STARTING_FROM = 25 * 60;
-const BREAK_STARTING_FROM = 5 * 60;
-const START_TEXT = "Start!";
-const STOP_TEXT = "Stop!";
-const PAUSE_TEXT = "Pause!";
-const RESUME_TEXT = "Resume!";
 
 export default class Timer {
   constructor($display, $button, $finishedCounter, $pauseButton) {
@@ -125,17 +127,20 @@ export default class Timer {
   }
 
   setPomodoroAsDone() {
+    let message;
+
     if (this.focusMode) {
       this.finishedPomodoros += 1;
+      message = MESSAGES.FOCUS_MODE_DONE;
+    } else {
+      message = MESSAGES.REST_MODE_DONE;
     }
 
     this.toggleFocusTime();
     this.stopTimer();
 
-    notify("Pomodoro done! Take a break!");
-    M.toast({
-      html: "Pomodoro done! :)"
-    });
+    notify(message);
+    M.toast({ html: message });
   }
 
   toggleFocusTime() {

--- a/tomaco/static/src/js/utils.js
+++ b/tomaco/static/src/js/utils.js
@@ -1,13 +1,13 @@
 const pad = numberToPad =>
   numberToPad.toString().length < 2 ? `0${numberToPad}` : numberToPad;
 
-const secondsToMinutesAndSeconds = seconds => {
+export const secondsToMinutesAndSeconds = seconds => {
   const formattedMinutes = pad(Math.floor(seconds / 60));
   const formattedSeconds = pad(seconds % 60);
   return `${formattedMinutes}:${formattedSeconds}`;
 };
 
-function notify(message) {
+export function notify(message) {
   if (window.Notification && Notification.permission === "granted") {
     const notification = new Notification(message);
 
@@ -18,5 +18,3 @@ function notify(message) {
     };
   }
 }
-
-export { notify, secondsToMinutesAndSeconds };

--- a/tomaco/static/tests/main.spec.js
+++ b/tomaco/static/tests/main.spec.js
@@ -1,4 +1,6 @@
 import Timer from "../src/js/main";
+import * as Utils from "../src/js/utils";
+import { MESSAGES, START_TEXT, STOP_TEXT } from "../src/js/constants";
 
 describe("Timer", () => {
   let $fakeButton;
@@ -54,7 +56,7 @@ describe("Timer", () => {
   describe("build", () => {
     it("should reset the timer", () => {
       expect(timer.isRunning).toBe(false);
-      expect($fakeButton.innerHTML).toEqual("Start!");
+      expect($fakeButton.innerHTML).toEqual(START_TEXT);
       expect($fakeCounter.innerHTML).toEqual("");
       expect($fakeDisplay.innerHTML).toEqual("25:00");
     });
@@ -93,14 +95,14 @@ describe("Timer", () => {
       timer.isRunning = false;
       timer.updateUI();
 
-      expect($fakeButton.innerHTML).toEqual("Start!");
+      expect($fakeButton.innerHTML).toEqual(START_TEXT);
     });
 
     it("should print button with stop text", () => {
       timer.isRunning = true;
       timer.updateUI();
 
-      expect($fakeButton.innerHTML).toEqual("Stop!");
+      expect($fakeButton.innerHTML).toEqual(STOP_TEXT);
     });
 
     it("should be a focus button when in focus mode", () => {
@@ -181,7 +183,7 @@ describe("Timer", () => {
 
       expect(timer.isRunning).toBe(true);
       expect(timer.focusMode).toBe(true);
-      expect($fakeButton.innerHTML).toEqual("Stop!");
+      expect($fakeButton.innerHTML).toEqual(STOP_TEXT);
     });
 
     it("should triggers the interval engine", () => {
@@ -230,8 +232,16 @@ describe("Timer", () => {
       timer.timerInterval();
 
       expect(M.toast).toHaveBeenCalledWith({
-        html: "Pomodoro done! :)"
+        html: MESSAGES.FOCUS_MODE_DONE
       });
+    });
+
+    it("should notify the user when timer reaches zero", () => {
+      jest.spyOn(Utils, "notify");
+      timer.seconds = 0;
+      timer.timerInterval();
+
+      expect(Utils.notify).toHaveBeenCalledWith(MESSAGES.FOCUS_MODE_DONE);
     });
 
     it("should increase the finished counter", () => {
@@ -247,6 +257,25 @@ describe("Timer", () => {
       timer.timerInterval();
 
       expect(timer.finishedPomodoros).toEqual(0);
+    });
+
+    it("should show a 'back to focus' toast when timer reaches zero", () => {
+      timer.seconds = 0;
+      timer.setBreakTime();
+      timer.timerInterval();
+
+      expect(M.toast).toHaveBeenCalledWith({
+        html: MESSAGES.REST_MODE_DONE
+      });
+    });
+
+    it("should notify the user to get back to focus mode when timer reaches zero", () => {
+      jest.spyOn(Utils, "notify");
+      timer.seconds = 0;
+      timer.setBreakTime();
+      timer.timerInterval();
+
+      expect(Utils.notify).toHaveBeenCalledWith(MESSAGES.REST_MODE_DONE);
     });
   });
 });


### PR DESCRIPTION
We were showing the same "Pomodoro done" message when rest and focus mode are done. With this change, we differ the messages given which timer has ended.

fix #37