### PR TITLE
fix: Update clean-css version to solve security warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,11 @@
             "ms": "^2.1.1"
           }
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2260,18 +2265,11 @@
       }
     },
     "clean-css": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.0.13.tgz",
-      "integrity": "sha1-/rKhdgYtcqbD5iTZITysagxIXoA=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "requires": {
-        "source-map": "0.5.x"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
+        "source-map": "~0.6.0"
       }
     },
     "clean-css-brunch": {
@@ -5734,9 +5732,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.4.4",
     "babel-brunch": "^7.0.1",
     "brunch": "^2.10.17",
+    "clean-css": "^4.2.1",
     "clean-css-brunch": "^2.10.0",
     "terser": "^4.0.2",
     "terser-brunch": "^3.0.0"


### PR DESCRIPTION
Github is warning us about the version of clean-css.

https://github.com/exa-team/tomaco/network/alert/package-lock.json/clean-css/closed

fix #54