### PR TITLE
feat(auth): Store the user on the database

### DIFF
--- a/tomaco/auth/models.py
+++ b/tomaco/auth/models.py
@@ -12,3 +12,17 @@ class User(db.Model):
 
     def __repr__(self):
         return "<id {}>".format(self.id)
+
+    def save(self):
+        db.session.add(self)
+
+    @staticmethod
+    def get_or_create(email):
+        user_instance = User.query.filter_by(email=email).first()
+        if user_instance:
+            return user_instance
+
+        user_instance = User(email=email)
+        user_instance.save()
+
+        return user_instance

--- a/tomaco/auth/tests/test_models.py
+++ b/tomaco/auth/tests/test_models.py
@@ -1,6 +1,8 @@
+import pytest
 from ..models import User
 
 
+@pytest.mark.usefixtures("db")
 class TestUser:
     USER_EMAIL = "gandalf@thegrey.com"
 
@@ -9,3 +11,24 @@ class TestUser:
         user.id = 1
 
         assert str(user) == "<id 1>"
+
+    def test_should_persist_user_in_the_database(self):
+        user = User(self.USER_EMAIL)
+        user.save()
+
+        assert User.query.count() == 1
+
+    def test_should_create_a_new_user_in_the_database(self):
+        user = User.get_or_create(self.USER_EMAIL)
+
+        assert type(user) == User
+        assert User.query.count() == 1
+
+    def test_should_get_the_user_from_database_when_it_exists(self):
+        user = User(self.USER_EMAIL)
+        user.save()
+
+        result = User.get_or_create(self.USER_EMAIL)
+
+        assert user == result
+        assert User.query.count() == 1

--- a/tomaco/auth/views.py
+++ b/tomaco/auth/views.py
@@ -11,8 +11,8 @@ from flask import (
 )
 
 from .exceptions import AuthException
+from .models import User, db
 from .utils import authorize_url, get_user_details, request_access_token
-from .models import User
 
 
 def login():
@@ -55,11 +55,10 @@ def login_complete():
     except AuthException:
         abort(401)
 
-    session["username"] = user_details["email"]
+    user = User.get_or_create(user_details["email"])
+    session["username"] = user.email
 
-    # It doesn't do anything, it's just a temporary hack so the
-    # Flask-Migrate is able to recognize the models module
-    User(user_details["email"])
+    db.session.commit()
 
     return redirect(url_for("index"))
 

--- a/tomaco/conftest.py
+++ b/tomaco/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tomaco import create_app
+from tomaco import create_app, db as app_db
 
 BASE_URL = "http://localhost"
 INDEX_URL = "{}/".format(BASE_URL)
@@ -11,6 +11,15 @@ USER_EMAIL = "should-be-user-email"
 @pytest.fixture
 def app():
     return create_app("tomaco.settings.Testing")
+
+
+@pytest.fixture
+def db(app):
+    with app.app_context():
+        app_db.create_all()
+        yield app_db
+        app_db.session.remove()
+        app_db.drop_all()
 
 
 @pytest.fixture


### PR DESCRIPTION
In order to show the user's progress we need first to store her/him. In this PR we implement that,
by letting the transactional control to the view (instead of adding it as the Model's
responsibility). It would be great to have a different layer of abstraction to deal with this kind
of thing (instead of relying on staticmethods/classmethods).

connects to #21