### PR TITLE
fix(auth): Use login field instead of email while connecting to Github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ help:
 	@echo "setup-database ............................ Configure the database for development purpose"
 	@echo "setup-dependencies ........................ Install frontend and backend dependencies"
 	@echo "makemigrate ............................... Create database migrations
-	@echo "migrate ................................... Run the database migration"
+	@echo "migrate-down .............................. Run the database migration (downgrade)"
+	@echo "migrate-up................................. Run the database migration (upgrade)"
 	@echo "test ...................................... Run frontend and backend tests"
 	@echo "test-javascript ........................... Run the frontend tests"
 	@echo "test-python ............................... Run the backend tests"
@@ -75,7 +76,11 @@ makemigrate:
 	@echo "Creating migrations..."
 	cd tomaco; flask db migrate
 
-migrate:
+migrate-down:
+	@echo "Downgrading migrations..."
+	cd tomaco; flask db downgrade
+
+migrate-up:
 	@echo "Running migrations..."
 	cd tomaco; flask db upgrade
 

--- a/tomaco/auth/models.py
+++ b/tomaco/auth/models.py
@@ -5,7 +5,8 @@ class User(db.Model):
     __tablename__ = "user"
 
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(), nullable=False)
+    email = db.Column(db.String(), nullable=True)
+    username = db.Column(db.String(), nullable=False, unique=True)
 
     def __repr__(self):
         return "<id {}>".format(self.id)
@@ -14,20 +15,20 @@ class User(db.Model):
         db.session.add(self)
 
     @staticmethod
-    def get_or_create(email):
+    def get_or_create(username, **kwargs):
         try:
-            return User.get(email)
+            return User.get(username=username)
         except DoesNotExist:
             pass
 
-        user_instance = User(email=email)
+        user_instance = User(username=username, **kwargs)
         user_instance.save()
 
         return user_instance
 
     @staticmethod
-    def get(email):
-        user_instance = User.query.filter_by(email=email).first()
+    def get(**kwargs):
+        user_instance = User.query.filter_by(**kwargs).first()
 
         if not user_instance:
             raise DoesNotExist()

--- a/tomaco/auth/tests/test_models.py
+++ b/tomaco/auth/tests/test_models.py
@@ -4,19 +4,20 @@ from tomaco.db import DoesNotExist
 
 from ..models import User
 
+USERNAME = "legolas"
 USER_EMAIL = "legolas@middleearth.com"
 
 
 @pytest.mark.usefixtures("db")
 class TestUser:
     def test_should_have_a_string_representation(self):
-        user = User(email=USER_EMAIL)
+        user = User(username=USERNAME, email=USER_EMAIL)
         user.id = 1
 
         assert str(user) == "<id 1>"
 
     def test_should_persist_user_in_the_database(self):
-        user = User(email=USER_EMAIL)
+        user = User(username=USERNAME, email=USER_EMAIL)
         user.save()
 
         assert User.query.count() == 1
@@ -25,13 +26,13 @@ class TestUser:
 @pytest.mark.usefixtures("db")
 class TestUserGetOrCreate:
     def test_should_create_a_new_user_in_the_database(self):
-        user = User.get_or_create(USER_EMAIL)
+        user = User.get_or_create(USERNAME, email=USER_EMAIL)
 
         assert type(user) == User
         assert User.query.count() == 1
 
     def test_should_get_the_user_from_database_when_it_exists(self, user):
-        result = User.get_or_create(user.email)
+        result = User.get_or_create(user.username, email=user.email)
 
         assert user.id == result.id
         assert User.query.count() == 1
@@ -40,11 +41,11 @@ class TestUserGetOrCreate:
 @pytest.mark.usefixtures("db")
 class TestUserGet:
     def test_should_return_an_user_instance_from_the_database(self, user):
-        result = User.get(user.email)
+        result = User.get(username=user.username)
 
         assert result.email == user.email
         assert user == result
 
     def test_should_raise_does_not_exist_when_user_is_not_found(self):
         with pytest.raises(DoesNotExist):
-            User.get(USER_EMAIL)
+            User.get(username=USERNAME)

--- a/tomaco/auth/tests/test_views.py
+++ b/tomaco/auth/tests/test_views.py
@@ -43,7 +43,7 @@ class TestLoginComplete(BaseTest):
 
     @pytest.fixture
     def get_user_details_mock(self, mocker, user):
-        data = {"email": user.email}
+        data = {"email": user.email, "login": user.username}
         return mocker.patch.object(views, "get_user_details", return_value=data)
 
     @pytest.fixture
@@ -70,7 +70,7 @@ class TestLoginComplete(BaseTest):
     ):
         self.get(client)
 
-        user_get_or_create_mock.assert_called_once_with(user.email)
+        user_get_or_create_mock.assert_called_once_with(user.username, email=user.email)
         db_session_commit_mock.assert_called()
 
     @pytest.mark.usefixtures(
@@ -80,7 +80,7 @@ class TestLoginComplete(BaseTest):
         self.get(client)
 
         with client.session_transaction() as sess:
-            assert sess["username"] == user.email
+            assert sess["username"] == user.username
 
     def test_should_show_a_unauthorized_when_authorization_fails(self, client, mocker):
         mocker.patch.object(

--- a/tomaco/auth/views.py
+++ b/tomaco/auth/views.py
@@ -55,8 +55,8 @@ def login_complete():
     except AuthException:
         abort(401)
 
-    user = User.get_or_create(user_details["email"])
-    session["username"] = user.email
+    user = User.get_or_create(user_details["login"], email=user_details["email"])
+    session["username"] = user.username
 
     db.session.commit()
 

--- a/tomaco/conftest.py
+++ b/tomaco/conftest.py
@@ -25,7 +25,7 @@ def db(app):
 
 @pytest.fixture
 def user(db):
-    user = User(email="bilbo@baggins.middleearth")
+    user = User(username="bbaggins", email="bilbo@baggins.middleearth")
     user.save()
 
     return user

--- a/tomaco/migrations/versions/7d0aea032eac_.py
+++ b/tomaco/migrations/versions/7d0aea032eac_.py
@@ -1,0 +1,49 @@
+"""Add username column
+
+Revision ID: 7d0aea032eac
+Revises: 707e0f9d6222
+Create Date: 2019-09-08 15:45:18.985125
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7d0aea032eac"
+down_revision = "707e0f9d6222"
+branch_labels = None
+depends_on = None
+
+# custom types, used by our data migration.
+user_helper = sa.Table(
+    "user",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer, primary_key=True),
+    sa.Column("email", sa.String(), nullable=False),
+    sa.Column("username", sa.String(), nullable=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    op.add_column("user", sa.Column("username", sa.String(), nullable=True))
+
+    for user in connection.execute(user_helper.select()):
+        if not user.email:
+            continue
+
+        username, _ = user.email.split("@")
+        connection.execute(
+            user_helper.update()
+            .where(user_helper.c.id == user.id)
+            .values(username=username)
+        )
+
+    op.alter_column("user", "username", nullable=False)
+    op.create_unique_constraint("uq_user_username", "user", ["username"])
+
+
+def downgrade():
+    op.drop_column("user", "username")

--- a/tomaco/migrations/versions/d5ba963e97fd_.py
+++ b/tomaco/migrations/versions/d5ba963e97fd_.py
@@ -1,0 +1,24 @@
+"""Set the email column as nullable
+
+Revision ID: d5ba963e97fd
+Revises: 7d0aea032eac
+Create Date: 2019-09-08 15:57:39.781235
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d5ba963e97fd"
+down_revision = "7d0aea032eac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("user", "email", existing_type=sa.VARCHAR(), nullable=True)
+
+
+def downgrade():
+    op.alter_column("user", "email", existing_type=sa.VARCHAR(), nullable=False)


### PR DESCRIPTION
The email field is an optional field on Github. We've been using this field as some sort of "foreign
key" to connect "our" user with the Github's account. With this change, we are now pointing to the
login/username field, which is (afaik) a required field on Github API.

fix #65